### PR TITLE
deprecation of GH set-output

### DIFF
--- a/.github/workflows/ct.yaml
+++ b/.github/workflows/ct.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --config ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/charts/dummy/Chart.yaml
+++ b/charts/dummy/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
rework set-output according to deprecation notice: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/