### PR TITLE
z2m: configuration of env vars

### DIFF
--- a/charts/zigbee2mqtt/Chart.yaml
+++ b/charts/zigbee2mqtt/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zigbee2mqtt/templates/deployment.yaml
+++ b/charts/zigbee2mqtt/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.zigbee2mqtt.env }}
+          env:
+{{ toYaml .Values.zigbee2mqtt.env | indent 12}}
+          {{- end }}
           # frontend expected to be running
           {{- if .Values.zigbee2mqtt.config.frontend }}
           ports:

--- a/charts/zigbee2mqtt/values.yaml
+++ b/charts/zigbee2mqtt/values.yaml
@@ -85,3 +85,5 @@ zigbee2mqtt:
       host: 0.0.0.0
     advanced:
       log_level: debug
+  # Additional environment variables
+  env: []


### PR DESCRIPTION
This adds the possibility to configure environment variables for the zigbee2mqtt chart. This allows configuration of e.g. TZ or overriding the configuration.yaml.